### PR TITLE
Toolbar color state position fix

### DIFF
--- a/app/src/main/java/com/derek_s/hubble_gallery/base/Constants.java
+++ b/app/src/main/java/com/derek_s/hubble_gallery/base/Constants.java
@@ -10,7 +10,6 @@ public class Constants {
     public static final String MODE_KEY = "current_mode";
     public static final String PARAM_TILE_KEY = "tile_param";
     public static final String PARAM_DETAILS_KEY = "details_param";
-    public static final String ALPHA_TITLE = "toolbar_current_alpha";
     public static final String ONBOARDING_SHOWN ="onboarding_shown";
 
     public static String imageDirectory() {

--- a/app/src/main/java/com/derek_s/hubble_gallery/ui/activities/ActDetails.java
+++ b/app/src/main/java/com/derek_s/hubble_gallery/ui/activities/ActDetails.java
@@ -1,7 +1,6 @@
 package com.derek_s.hubble_gallery.ui.activities;
 
 import android.content.Intent;
-import android.net.Uri;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 
@@ -9,7 +8,7 @@ import com.derek_s.hubble_gallery.R;
 import com.derek_s.hubble_gallery.base.Constants;
 import com.derek_s.hubble_gallery.ui.fragments.FragDetails;
 
-public class ActDetails extends AppCompatActivity implements FragDetails.OnFragmentInteractionListener {
+public class ActDetails extends AppCompatActivity {
 
     private String TAG = getClass().getSimpleName();
     FragDetails fragDetails;
@@ -35,10 +34,4 @@ public class ActDetails extends AppCompatActivity implements FragDetails.OnFragm
         super.onBackPressed();
         this.overridePendingTransition(R.anim.fade_in_shadow, R.anim.slide_out_right);
     }
-
-    @Override
-    public void onFragmentInteraction(Uri uri) {
-        // TODO
-    }
-
 }

--- a/app/src/main/java/com/derek_s/hubble_gallery/ui/fragments/FragDetails.java
+++ b/app/src/main/java/com/derek_s/hubble_gallery/ui/fragments/FragDetails.java
@@ -65,6 +65,9 @@ available resolution
 public class FragDetails extends android.support.v4.app.Fragment implements ObservableScrollViewCallbacks {
 
     private static String TAG = "FragDetails";
+    private static final String TOOLBAR_CURRENT_ALPHA = "toolbar_current_alpha";
+    private static final String TOOLBAR_COLOR = "toolbar_current_color";
+
     private TileObject tileObject;
     private DetailsObject detailsObject;
     @InjectView(R.id.iv_display)
@@ -85,14 +88,13 @@ public class FragDetails extends android.support.v4.app.Fragment implements Obse
     TextView tvZeroStateInfo;
     @InjectView(R.id.tv_retry)
     TextView tvRetry;
+
     int imgLoadAttempt = 0;
     public static String successfulSrc;
     int titleBgColor;
     int alphaTitleBgColor;
     FavoriteUtils favoriteUtils;
     MenuItem actionFavorite;
-
-    private OnFragmentInteractionListener mCallbacks;
 
     /*
     must pass a TileObject for the fragment to use
@@ -266,15 +268,20 @@ public class FragDetails extends android.support.v4.app.Fragment implements Obse
                 showDialog();
             }
         });
-
         scrollView.setScrollViewCallbacks(this);
 
         showLoadingAnimation(true, 0);
         if (savedInstanceState != null) {
             loadImage(tileObject.getSrc());
-            onScrollChanged(scrollView.getCurrentScrollY(), false, false);
-            alphaTitleBgColor = savedInstanceState.getInt(Constants.ALPHA_TITLE);
+            titleBgColor = savedInstanceState.getInt(TOOLBAR_COLOR);
+            alphaTitleBgColor = savedInstanceState.getInt(TOOLBAR_CURRENT_ALPHA);
             toolbar.setBackgroundColor(alphaTitleBgColor);
+
+            scrollView.post(new Runnable() {
+                public void run() {
+                    scrollView.scrollTo(0, scrollView.getCurrentScrollY());
+                }
+            });
 
             if (detailsObject == null) {
                 loadPage();
@@ -478,18 +485,11 @@ public class FragDetails extends android.support.v4.app.Fragment implements Obse
     @Override
     public void onAttach(Activity activity) {
         super.onAttach(activity);
-        try {
-            mCallbacks = (OnFragmentInteractionListener) activity;
-        } catch (ClassCastException e) {
-            throw new ClassCastException(activity.toString()
-                    + " must implement OnFragmentInteractionListener");
-        }
     }
 
     @Override
     public void onDetach() {
         super.onDetach();
-        mCallbacks = null;
     }
 
     @Override
@@ -497,7 +497,9 @@ public class FragDetails extends android.support.v4.app.Fragment implements Obse
         outstate.putString(Constants.PARAM_TILE_KEY, tileObject.serialize());
         if (detailsObject != null)
             outstate.putString(Constants.PARAM_DETAILS_KEY, detailsObject.serialize());
-        outstate.putInt(Constants.ALPHA_TITLE, alphaTitleBgColor);
+
+        outstate.putInt(TOOLBAR_CURRENT_ALPHA, alphaTitleBgColor);
+        outstate.putInt(TOOLBAR_COLOR, titleBgColor);
         super.onSaveInstanceState(outstate);
     }
 
@@ -521,9 +523,4 @@ public class FragDetails extends android.support.v4.app.Fragment implements Obse
     @Override
     public void onUpOrCancelMotionEvent(ScrollState scrollState) {
     }
-
-    public interface OnFragmentInteractionListener {
-        public void onFragmentInteraction(Uri uri);
-    }
-
 }


### PR DESCRIPTION
Now it's based on the scrollview Y position, calling scrollTo in a runnable is a lot more reliable and keeps the image parallax aligned correctly as well since the obersvableScrollView interfaces are already set to immedately update on it's scroll change.

Also cleaned up instance state handing and removed unused onFragmentInteraction interface.
